### PR TITLE
chore: bump mysql-operator version to v0.2.1

### DIFF
--- a/charts/mysql-operator/Chart.yaml
+++ b/charts/mysql-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: v0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.0"
+appVersion: "v0.2.1"


### PR DESCRIPTION
# Why
- New version [v0.2.1](https://github.com/nakamasato/mysql-operator/releases/tag/v0.2.1) was released.
# What
- bump mysql-operator chart version to [v0.2.1](https://github.com/nakamasato/mysql-operator/releases/tag/v0.2.1)