### PR TITLE
chore: bump mysql-operator version to v0.3.0

### DIFF
--- a/charts/mysql-operator/Chart.yaml
+++ b/charts/mysql-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.2.2
+version: v0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.2"
+appVersion: "v0.3.0"

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -3,7 +3,7 @@ controllerManager:
   manager:
     image:
       repository: ghcr.io/nakamasato/mysql-operator
-      tag: v0.2.2
+      tag: v0.3.0
     resources:
       limits:
         cpu: 200m
@@ -25,8 +25,8 @@ managerConfig:
       port: 9443
 metricsService:
   ports:
-  - name: https
-    port: 8443
-    protocol: TCP
-    targetPort: https
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
   type: ClusterIP


### PR DESCRIPTION
# Why
- New version [v0.3.0](https://github.com/nakamasato/mysql-operator/releases/tag/v0.3.0) was released.
# What
- bump mysql-operator chart version to [v0.3.0](https://github.com/nakamasato/mysql-operator/releases/tag/v0.3.0)