### PR TITLE
chore: bump v0.4.1 (support k8s secret)

### DIFF
--- a/charts/mysql-operator/Chart.yaml
+++ b/charts/mysql-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.3.3
+version: v0.4.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.3.3"
+appVersion: "v0.4.1"

--- a/charts/mysql-operator/README.md
+++ b/charts/mysql-operator/README.md
@@ -2,12 +2,12 @@
 
 ## Values
 
-1. **cloudSecretManagerType**: `raw` or `gcp`. With `raw`, you need to give root user password in `MySQL` custom resource. With `gcp`, you can securely store root user password in GCP SecretManager. This root user password is used to manage (create/edit/update) MySQL users, databases, etc.
-1. **gcpServiceAccount**: Only for `cloudSecretManagerType=gcp`. GCP service account for Pod `SA_NAME@PROJECT.iam.gserviceaccount.com`
+1. **adminUserSecretType**: `raw`, `gcp` or `k8s` . With `raw`, you need to give root user password in `MySQL` custom resource. With `gcp`, you can securely store root user password in GCP SecretManager. This root user password is used to manage (create/edit/update) MySQL users, databases, etc. With k8s you need to create (in the same namespace where this operator is installed) two kubernetes secrets one for the root username and another one for root password.
+1. **gcpServiceAccount**: Only for `adminUserSecretType=gcp`. GCP service account for Pod `SA_NAME@PROJECT.iam.gserviceaccount.com`
     1. This service account needs the following roles:
         1. `roles/secretmanager.secretAccessor` to allow to get root password from SecretManager
-
-1. **gcpProjectId**: Only for `cloudSecretManagerType=gcp`
+1. **gcpProjectId**: Only for `adminUserSecretType=gcp`
+1. **adminUserSecretNamespace**: Only for `adminUserSecretType=k8s`. Kubernetes Namespace of Secret for MySQL admin user credentials.
 1. **cloudSQL.instanceConnectionName**: `InstanceConnectionName` for [Google Cloud SQL](https://cloud.google.com/sql/) if you use Cloud SQL to manage with mysql-operator. `<project-id>:<region>:<instance-name>`
 
 
@@ -21,7 +21,7 @@ You can check the final yaml with `--dry-run`:
 ```
 helm install mysql-operator ./charts/mysql-operator \
     --dry-run \
-    --set cloudSecretManagerType=gcp \
+    --set adminUserSecretType=gcp \
     --set gcpServiceAccount=${SA_NAME}@${PROJECT}.iam.gserviceaccount.com \
     --set gcpProjectId=$PROJECT \
     --set cloudSQL.instanceConnectionName=$PROJECT:$REGION:$INSTANCE_NAME \
@@ -32,7 +32,7 @@ helm install mysql-operator ./charts/mysql-operator \
 
 ```
 helm install mysql-operator ./charts/mysql-operator \
-    --set cloudSecretManagerType=gcp \
+    --set adminUserSecretType=gcp \
     --set gcpServiceAccount=${SA_NAME}@${PROJECT}.iam.gserviceaccount.com \
     --set gcpProjectId=$PROJECT \
     --set cloudSQL.instanceConnectionName=$PROJECT:$REGION:$INSTANCE_NAME \

--- a/charts/mysql-operator/crds/mysql-crd.yaml
+++ b/charts/mysql-operator/crds/mysql-crd.yaml
@@ -1,11 +1,10 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mysqls.mysql.nakamasato.com
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  labels:
-  {{- include "chart.labels" . | nindent 4 }}
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: mysqls.mysql.nakamasato.com
 spec:
   group: mysql.nakamasato.com
   names:
@@ -42,20 +41,25 @@ spec:
         description: MySQL is the Schema for the mysqls API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: MySQLSpec holds the connection information for the target MySQL
-              cluster.
+            description: MySQLSpec holds the connection information for the target
+              MySQL cluster.
             properties:
               adminPassword:
                 description: AdminPassword is MySQL password to connect target MySQL
@@ -65,10 +69,11 @@ spec:
                     description: Secret Name
                     type: string
                   type:
-                    description: Secret Type (e.g. gcp, raw)
+                    description: Secret Type (e.g. gcp, raw, k8s)
                     enum:
                     - raw
                     - gcp
+                    - k8s
                     type: string
                 required:
                 - name
@@ -81,10 +86,11 @@ spec:
                     description: Secret Name
                     type: string
                   type:
-                    description: Secret Type (e.g. gcp, raw)
+                    description: Secret Type (e.g. gcp, raw, k8s)
                     enum:
                     - raw
                     - gcp
+                    - k8s
                     type: string
                 required:
                 - name
@@ -130,9 +136,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/mysql-operator/crds/mysqldb-crd.yaml
+++ b/charts/mysql-operator/crds/mysqldb-crd.yaml
@@ -1,11 +1,10 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mysqldbs.mysql.nakamasato.com
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  labels:
-  {{- include "chart.labels" . | nindent 4 }}
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: mysqldbs.mysql.nakamasato.com
 spec:
   group: mysql.nakamasato.com
   names:
@@ -34,14 +33,19 @@ spec:
         description: MySQLDB is the Schema for the mysqldbs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -101,9 +105,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/mysql-operator/crds/mysqluser-crd.yaml
+++ b/charts/mysql-operator/crds/mysqluser-crd.yaml
@@ -1,11 +1,10 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: mysqlusers.mysql.nakamasato.com
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  labels:
-  {{- include "chart.labels" . | nindent 4 }}
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: mysqlusers.mysql.nakamasato.com
 spec:
   group: mysql.nakamasato.com
   names:
@@ -38,14 +37,19 @@ spec:
         description: MySQLUser is the Schema for the mysqlusers API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -69,43 +73,43 @@ spec:
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a foo's
-                    current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details
-                        about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers of
-                        specific condition types may define expected values and meanings
-                        for this field, and whether the values are considered a guaranteed
-                        API. The value should be a CamelCase string. This field may
-                        not be empty.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -118,11 +122,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -155,9 +160,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/mysql-operator/templates/deployment.yaml
+++ b/charts/mysql-operator/templates/deployment.yaml
@@ -31,8 +31,9 @@ spec:
       containers:
       - args:
         - --leader-elect
-        {{- if eq .Values.cloudSecretManagerType "gcp" }}
-        - --cloud-secret-manager=gcp
+        - --admin-user-secret-type={{ .Values.adminUserSecretType | default "raw" }}
+        {{- if eq .Values.adminUserSecretType "k8s" }}
+        - --k8s-secret-namespace={{ .Values.k8sSecretNamespace | default "default" }}
         {{- end }}
         command:
         - /manager
@@ -56,7 +57,7 @@ spec:
           }}
         securityContext:
           allowPrivilegeEscalation: false
-        {{- if eq .Values.cloudSecretManagerType "gcp" }}
+        {{- if eq .Values.adminUserSecretType "gcp" }}
         {{- if .Values.gcpServiceAccount }}
         env:
           - name: PROJECT_ID
@@ -110,7 +111,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ include "chart.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
-      {{- if and (eq .Values.cloudSecretManagerType "gcp") (empty .Values.gcpServiceAccount) }}
+      {{- if and (eq .Values.adminUserSecretType "gcp") (empty .Values.gcpServiceAccount) }}
       volumes:
         - name: gcp-sa-private-key
           secret:

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -1,15 +1,17 @@
-cloudSecretManagerType: raw # set gcp if you use GCP SecretManager
+# set gcp if you use GCP SecretManager
+# set k8s if you use Kubernetes secrets
+adminUserSecretType: raw # set gcp if you use GCP SecretManager
 # gcpServiceAccount: GSA_NAME@GSA_PROJECT.iam.gserviceaccount.com
 # gcpProjectId: <projectid>
 # cloudSQL:
 #   instanceConnectionName:
 #   enableIamAuth: false
 #   usePrivateIp: false
+k8sSecretNamespace: default
 controllerManager:
   manager:
     image:
       repository: ghcr.io/nakamasato/mysql-operator
-      tag: v0.4.0
     resources:
       limits:
         cpu: 200m


### PR DESCRIPTION
# why

From #23 

# what

- Move crd from templates (removed templated labels)
- Update crd from latest mysql-operator: https://github.com/nakamasato/mysql-operator/releases/tag/v0.4.1
- Update name `adminUserSecretType` https://github.com/nakamasato/mysql-operator/pull/396 released in https://github.com/nakamasato/mysql-operator/releases/tag/v0.4.1
- 