### PR TITLE
chore: bump mysql-operator version to v0.4.2

### DIFF
--- a/charts/mysql-operator/Chart.yaml
+++ b/charts/mysql-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.4.1
+version: v0.4.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.1"
+appVersion: "v0.4.2"

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -12,6 +12,7 @@ controllerManager:
   manager:
     image:
       repository: ghcr.io/nakamasato/mysql-operator
+      tag: v0.4.2
     resources:
       limits:
         cpu: 200m


### PR DESCRIPTION
# Why
- New version [v0.4.2](https://github.com/nakamasato/mysql-operator/releases/tag/v0.4.2) was released.
# What
- bump mysql-operator chart version to [v0.4.2](https://github.com/nakamasato/mysql-operator/releases/tag/v0.4.2)