### PR TITLE
chore: bump mysql-operator version to v0.4.3

### DIFF
--- a/charts/mysql-operator/Chart.yaml
+++ b/charts/mysql-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.4.2
+version: v0.4.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.2"
+appVersion: "v0.4.3"

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -12,7 +12,7 @@ controllerManager:
   manager:
     image:
       repository: ghcr.io/nakamasato/mysql-operator
-      tag: v0.4.2
+      tag: v0.4.3
     resources:
       limits:
         cpu: 200m


### PR DESCRIPTION
# Why
- New version [v0.4.3](https://github.com/nakamasato/mysql-operator/releases/tag/v0.4.3) was released.
# What
- bump mysql-operator chart version to [v0.4.3](https://github.com/nakamasato/mysql-operator/releases/tag/v0.4.3)